### PR TITLE
Add plugin to drop old deployments.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "jest": "^24.9.0",
-    "serverless": "^1.54.0"
+    "serverless": "^1.54.0",
+    "serverless-prune-plugin": "^1.4.2"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -84,3 +84,11 @@ package:
     - .secret/credentials.json
   exclude:
     - ./**
+
+custom:
+  prune:
+    automatic: true
+    number: 5
+
+plugins:
+  - serverless-prune-plugin

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,11 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+bluebird@^3.4.7:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
 bluebird@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.0.tgz#56a6a886e03f6ae577cffedeb524f8f2450293cf"
@@ -5198,6 +5203,13 @@ serve-static@1.14.1:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.17.1"
+
+serverless-prune-plugin@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/serverless-prune-plugin/-/serverless-prune-plugin-1.4.2.tgz#785ae3f90fe2f505078c5d1663a2724bd2b64833"
+  integrity sha512-GHyvmKjWDPLts2jIFujiT5cxuNp1tD9HxC3WQCxeZWP0yqb7O3zJYJcEP/wWpH87QfUZGbirzrzOQbzunDN77w==
+  dependencies:
+    bluebird "^3.4.7"
 
 serverless@^1.54.0:
   version "1.54.0"


### PR DESCRIPTION
This is done after the suggestions of [this article](https://medium.com/fluidity/the-dark-side-of-aws-lambda-5c9f620b7dd2).